### PR TITLE
Return item count + 1 logic

### DIFF
--- a/lib/src/loadable/loadable_list_view.dart
+++ b/lib/src/loadable/loadable_list_view.dart
@@ -116,8 +116,6 @@ class LoadableListViewState extends State<LoadableListView> {
         ),
       ),
       // ignore: avoid-returning-widgets
-      SliverToBoxAdapter(child: buildLastItem(state)),
-      // ignore: avoid-returning-widgets
       if (viewModel.footer != null) buildFooter(),
     ];
   }

--- a/lib/src/loadable/loadable_paginated_list_view.dart
+++ b/lib/src/loadable/loadable_paginated_list_view.dart
@@ -27,6 +27,14 @@ class LoadablePaginatedListState extends LoadableListViewState {
       widget.viewModel as LoadablePaginatedListViewModel;
 
   @override
+  Widget buildListItem(int index) {
+    return index == viewModel.itemCount - 1
+        // ignore: avoid-returning-widgets
+        ? buildLastItem(viewModel.getPaginationState())
+        : super.buildListItem(index);
+  }
+
+  @override
   Widget buildFooter() {
     return SliverToBoxAdapter(
       child: viewModel.isAllItemsLoaded ? viewModel.footer : null,
@@ -77,7 +85,7 @@ class LoadablePaginatedListViewModel extends LoadableListViewModel {
     required super.errorWidget,
     required super.emptyStateWidget,
     required super.loadListRequestState,
-    required super.itemCount,
+    required int itemCount,
     required this.loadPageRequestState,
     required this.errorPageWidget,
     required this.isAllItemsLoaded,
@@ -88,7 +96,7 @@ class LoadablePaginatedListViewModel extends LoadableListViewModel {
     super.footer,
     this.loadPage,
     super.key,
-  });
+  }) : super(itemCount: itemCount + 1);
 
   final VoidCallback? loadPage;
   final Widget errorPageWidget;


### PR DESCRIPTION
The padding is pushing the loader to the bottom with padding.bottom white space between list and loader.

Seems that returning the old itemCount + 1 logic for the last item as a loader is the easiest way to solve that problem. This solution also doesn't affect the glowing effect on Android.